### PR TITLE
no longer let the function make a copy to backup

### DIFF
--- a/instrbuilder/instrument_opening.py
+++ b/instrbuilder/instrument_opening.py
@@ -163,9 +163,6 @@ def append_to_yaml(new_configs, filename='config.yaml'):
         print('Error: instruments key is in the new configuration dictionary')
         return
 
-    # copy YAML
-    os.rename(os.path.join(home, filename), os.path.join(home, filename).replace('.yaml', '_backup.yaml'))
-
     # append new dictionary to old dictionary
     if 'instruments' not in configs:
         configs['instruments'] = {}
@@ -175,7 +172,6 @@ def append_to_yaml(new_configs, filename='config.yaml'):
     with open(os.path.join(home, filename), 'w+') as f:
         # see: https://pyyaml.org/wiki/PyYAMLDocumentation (for default_flow_style)
         yaml.dump(configs, f, default_flow_style=False)
-    os.remove(os.path.join(home, filename).replace('.yaml', '_backup.yaml'))
     return
 
 


### PR DESCRIPTION
no need to let the function make a copy to backup. when there are multiple instruments it puts the process into a loop and hence calls `append_to_yaml()` multiple times, which also renames to`backup.yaml` multiple times leading to naming conflict