### PR TITLE
Add error buffer flush and trigger holdoff commands (T1 control)

### DIFF
--- a/instrbuilder/examples/delay_gen.py
+++ b/instrbuilder/examples/delay_gen.py
@@ -5,6 +5,7 @@
 
 '''
 Demonstrate the delay generator within instrbuilder
+An example of common commands used.
 '''
 
 from instrbuilder.instrument_opening import open_by_name
@@ -22,15 +23,25 @@ print("A after:", dg.get("delay", configs={"channel": 2}))
 # Last error gives the last error in the buffer. Error lookup table is in the DG645 Manual
 print("Last error:", dg.get("last_error"))
 
-dg.set("trigger_source", 0) # Changes the type of trigger
+dg.set("trigger_source", 0) # Changes the type of trigger (0-6)
 dg.set("trigger_rate", 10000000.0) # Changes rate at which the triggers occur (Hz)
 
 # Changing amplitude of outputs
 dg.set("amplitude", 2.5, configs={"output": 0}) # T0
 dg.set("amplitude", 2.5, configs={"output": 1}) # AB
 
-dg.set("delay", 10e-9, configs={"channel": 3, "reference": 2})
+dg.set("delay", 100e-9, configs={"channel": 3, "reference": 2}) # Use to modify delay band width (AB, CD, EF, GH)
 
+
+# Use to clear the error buffer
+while True:
+    err = dg.get("last_error")
+
+    if err not in ("0", 0, "NO ERROR"):
+        print("Error:", err)
+    else:
+        break
+
+# Closing port and giving control back to local/manual operation
 dg.set("local")
-
 dg.comm_handle.close()

--- a/instrbuilder/examples/delay_gen.py
+++ b/instrbuilder/examples/delay_gen.py
@@ -17,7 +17,7 @@ dg = open_by_name(name='dg645')
 dg.set("reset")
 
 print("A before:", dg.get("delay", configs={"channel": 2}))
-dg.set("delay", 6e-9, configs={"channel": 2, "reference": 0})
+dg.set("delay", 10e-9, configs={"channel": 2, "reference": 0})
 print("A after:", dg.get("delay", configs={"channel": 2}))
 
 # Last error gives the last error in the buffer. Error lookup table is in the DG645 Manual
@@ -31,6 +31,9 @@ dg.set("amplitude", 2.5, configs={"output": 0}) # T0
 dg.set("amplitude", 2.5, configs={"output": 1}) # AB
 
 dg.set("delay", 100e-9, configs={"channel": 3, "reference": 2}) # Use to modify delay band width (AB, CD, EF, GH)
+
+dg.set("adv_trig_en", 1) # Enables Advanced Triggering for Trigger Holdoff
+dg.set("trigger_holdoff", 136e-9) # Sets T1 (must be at least 25ns after longest programmed delay) (A=10ns, B=100ns, T >= A + B + 25ns =135ns)
 
 
 # Use to clear the error buffer

--- a/instrbuilder/instruments/srs/delay_generator/dg645/commands.csv
+++ b/instrbuilder/instruments/srs/delay_generator/dg645/commands.csv
@@ -3,9 +3,11 @@ id,*IDN?,*IDN?,TRUE,str,FALSE,none,None,Read the DG645 device identification str
 reset,*RST,,FALSE,none,TRUE,none,None,Reset the unit to default configurations.,interface,FALSE,,
 local,LCAL,,FALSE,none,TRUE,none,None,Return the DG645 to local/front-panel control.,interface,FALSE,,
 last_error,LERR,LERR?,TRUE,str,FALSE,none,None,Read the last error from the DG645 error queue.,status,FALSE,,
+adv_trig_en,ADVT {value},ADVT?,TRUE,bool,TRUE,bool,"[0,1]",Enable/query advanced triggering mode.,trigger,TRUE,1,0
 trigger,*TRG,,FALSE,none,TRUE,none,None,Trigger a delay cycle.,trigger,FALSE,,
 trigger_level,TLVL {value},TLVL?,TRUE,float,TRUE,float,"[-3.5,3.5]",Set/query external trigger threshold level in volts.,trigger,TRUE,1,0
 trigger_rate,TRAT {value},TRAT?,TRUE,float,TRUE,float,"[0.0001,10000000]",Set/query internal trigger rate in Hz.,trigger,TRUE,1,0
+trigger_holdoff,HOLD {value},HOLD?,TRUE,float,TRUE,float,"[0,2000]",Set/query trigger holdoff in seconds. Minimum time between successive triggers.,trigger,TRUE,1,0
 trigger_source,TSRC,TSRC?,TRUE,int,TRUE,int,"[0,6]",Set/query trigger source. 0=internal 1=external rising 2=external falling 3=single-shot external rising 4=single-shot external falling 5=single-shot 6=line.,trigger,TRUE,1,0
 delay,"DLAY {channel},{reference},{value}",DLAY?{channel},TRUE,str,TRUE,float,"[0,2000]", Set/query delay channel relative to a reference channel. Channels: 0=T0 1=T1 2=A 3=B 4=C 5=D 6=E 7=F 8=G 9=H.,delay,TRUE,3,1
 amplitude,"LAMP {output},{value}",LAMP?{output},TRUE,float,TRUE,float,"[0.5,5.0]",Set/query front panel output amplitude. Outputs: 0=T0 1=AB 2=CD 3=EF 4=GH,output,TRUE,2,1


### PR DESCRIPTION
DG645 stores up to the last 20 errors in a queue data structure. To poll/remove errors from the buffer, you have to call the last_error command for each error in the queue. Resetting the device only resets the measurement settings, not the delay buffer.

Controlling T1 is done by using the Trigger Holdoff command after enabling Advanced Triggering. T1 must be 25 ns longer than the longest programmed delay. This is limited because of hardware restrictions.